### PR TITLE
Fix: Improve reporting performance and clarity

### DIFF
--- a/examples/demo_models.py
+++ b/examples/demo_models.py
@@ -359,7 +359,7 @@ def main():
                     layer_idx += 1
             dnn_manager.map_dnn_to_hardware(weight_data)
             
-            create_complete_text_report(chip, dnn_manager, result)
+            create_complete_text_report(chip, dnn_manager, result, detailed_endurance_report=False)
             break
     
     print(f"\n🏁 All demos completed!")

--- a/main.py
+++ b/main.py
@@ -265,7 +265,7 @@ def run_simulation(args):
         print("\n6. Generating text-based visualization...")
         try:
             if args.execute and 'result' in locals():
-                create_complete_text_report(chip, dnn_manager, result)
+                create_complete_text_report(chip, dnn_manager, result, detailed_endurance_report=False)
             else:
                 print_architecture_diagram(chip)
             print("   ✓ Text visualization complete!")


### PR DESCRIPTION
This commit addresses three issues:

1.  **Reporting Performance (`demo_models.py` Timeout):**
    - I modified `CrossbarArray._get_endurance_status()` to accept a `detailed` flag (default True). If False, it returns placeholder values, avoiding costly cell-by-cell iteration.
    - `CrossbarArray.get_statistics()` now accepts `detailed_endurance` (default True) and passes it to `_get_endurance_status()`.
    - `text_viz.print_detailed_hardware_analysis()` now accepts `detailed_endurance` (default True) and passes it to `crossbar.get_statistics()`. It also conditionally prints endurance info.
    - `text_viz.create_complete_text_report()` now accepts `detailed_endurance_report` (default False) and passes it down.
    - `examples/demo_models.py` calls `create_complete_text_report()` with `detailed_endurance_report=False`.
    - *Verification:* `examples/demo_models.py` now completes without timeout, and the report indicates skipped endurance details.

2.  **Misleading Microcontroller IPC:**
    - I modified `text_viz.print_performance_summary()` to check if `total_instructions_executed` is 0.
    - If so, IPC is reported as "N/A (detailed MCU sim inactive or no instructions executed)".
    - *Verification:*
        - `main.py --execute --visualize` (default, non-cycle-accurate) would show "N/A" (verified by code inspection as the command itself timed out due to a separate issue).
        - `main.py --execute --visualize --cycle-accurate` correctly shows a numerical IPC.

3.  **Unclear Buffer Utilization Note:**
    - I modified `text_viz.print_bottleneck_analysis()` to add a note if global or shared buffers have <10% utilization, explaining it might be due to workload size.
    - *Verification:* Code inspection confirmed the note would be displayed under appropriate conditions. (Live test hampered by intermittent script execution issues).

The timeout issue with `main.py --execute --visualize` (non-cycle-accurate) remains and seems separate from the endurance calculation, requiring further investigation.