### PR TITLE
Docs: Update README and main.py help for model selection feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,22 @@ result = quick_simulation(execute_inference=True)
 python examples/demo_models.py
 ```
 
+### Example 6: Running Different Models with `main.py`
+
+The `main.py` script can run different predefined neural network models using the `--model` argument.
+The default model is `sample_cnn`. Other available models currently include `tiny_cnn` and `lenet`.
+
+```bash
+# Run the default SampleCNN model (same as without --model)
+python main.py --model sample_cnn --execute --visualize
+
+# Run TinyCNN model
+python main.py --model tiny_cnn --execute --visualize
+
+# Run LeNet model
+python main.py --model lenet --execute --visualize
+```
+
 ## 🎯 New Visualization Features
 
 ### 🔄 Live Visualization
@@ -479,8 +495,14 @@ python examples/simple_test.py
 # Multiple model demos
 python examples/demo_models.py
 
-# Main interface
+# Main interface (runs default SampleCNN)
 python main.py --execute --visualize
+
+# Run TinyCNN with main.py
+python main.py --model tiny_cnn --execute --visualize
+
+# Run LeNet with main.py
+python main.py --model lenet --execute --visualize
 ```
 
 ### Model Examples

--- a/main.py
+++ b/main.py
@@ -433,6 +433,10 @@ Examples:
   
   # Generate comprehensive analysis with architecture exploration
   python main.py --execute --visualize --explore-arch
+
+  # Run with a specific model (e.g., tiny_cnn, lenet)
+  python main.py --model tiny_cnn --execute --visualize
+  python main.py --model lenet --execute
         """
     )
     


### PR DESCRIPTION
This commit updates the documentation to reflect the recently added `--model` command-line argument in `main.py`.

Modifications:

1.  **`README.md`:**
    - Added a new example section under "Quick Examples" (Example 4) detailing how to use `--model` with `sample_cnn`, `tiny_cnn`, and `lenet`.
    - Updated the "Examples Library" -> "Basic Examples" section to clarify that `main.py` runs `sample_cnn` by default and to show explicit examples for running `tiny_cnn` and `lenet` via `main.py`.

2.  **`main.py`:**
    - Updated the `epilog` string of the `ArgumentParser` to include usage examples for the `--model` argument, ensuring this information is available via `python main.py --help`.

These changes make it easier for you to discover and utilize the new model selection capabilities.