### PR TITLE
Fix dtype for buffer writes

### DIFF
--- a/src/core/execution_engine.py
+++ b/src/core/execution_engine.py
@@ -896,7 +896,7 @@ class ExecutionEngine:
 
             if buffer_id is not None:
                 # Create dummy data for write
-                dummy_data = np.zeros(num_words_for_alloc)
+                dummy_data = np.zeros(num_words_for_alloc, dtype=np.float32)
 
                 # Simulate write request
                 request_id = self.system.buffer_manager.write_data(buffer_name, buffer_id, 0, dummy_data, requester_id)

--- a/src/core/microcontroller.py
+++ b/src/core/microcontroller.py
@@ -619,7 +619,7 @@ class Microcontroller:
             num_words = int(np.prod(output_shape))
             region_id = self.buffer_manager.allocate_buffer(target_buffer, num_words, "mcu_store")
             if region_id is not None:
-                dummy = np.zeros(num_words)
+                dummy = np.zeros(num_words, dtype=np.float32)
                 req_id = self.buffer_manager.write_data(target_buffer, region_id, 0, dummy, "mcu_store")
                 while req_id is not None and not self.buffer_manager.controllers[target_buffer].is_request_complete(req_id):
                     self.buffer_manager.tick_all()


### PR DESCRIPTION
## Summary
- ensure simulated writes allocate word-based arrays with float32 dtype

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684bac400988832f84348e6723656463