### PR TITLE
Fix BufferManager write_data size calculation

### DIFF
--- a/src/core/memory_system.py
+++ b/src/core/memory_system.py
@@ -334,7 +334,10 @@ class BufferManager:
             return None
             
         address = start_addr + offset
-        data_size_bits = buffer['config'].word_size_bits  # Assuming one word
+        num_words = 1
+        if isinstance(data, (list, tuple, np.ndarray)):
+            num_words = len(data)
+        data_size_bits = num_words * buffer['config'].word_size_bits
         
         return self.controllers[buffer_name].schedule_request(
             address, data_size_bits, AccessType.WRITE, data, 

--- a/tests/test_buffer_write_size.py
+++ b/tests/test_buffer_write_size.py
@@ -1,0 +1,17 @@
+import numpy as np
+from src.core.memory_system import BufferManager, MemoryConfig, MemoryType
+
+
+def test_write_request_size_matches_data_length():
+    cfg = {'buf': MemoryConfig(memory_type=MemoryType.SRAM, size_kb=4, banks=1, word_size_bits=32)}
+    bm = BufferManager(cfg)
+    region_id = bm.allocate_buffer('buf', size_words=16)
+    assert region_id is not None
+    data = [1, 2, 3, 4]
+    req_id = bm.write_data('buf', region_id, 0, data)
+    assert req_id is not None
+    controller = bm.controllers['buf']
+    assert controller.request_queue, "No request queued"
+    queued_request = controller.request_queue[0][2]
+    expected_bits = len(data) * cfg['buf'].word_size_bits
+    assert queued_request.size_bits == expected_bits


### PR DESCRIPTION
## Summary
- ensure write_data request size covers multi-word writes
- add a regression test for write request sizing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684bb65b9c18832f8a7f878adae002df