### PR TITLE
Fix write_data data size calc for arrays

### DIFF
--- a/src/core/memory_system.py
+++ b/src/core/memory_system.py
@@ -335,8 +335,10 @@ class BufferManager:
             
         address = start_addr + offset
         num_words = 1
-        if isinstance(data, (list, tuple, np.ndarray)):
+        try:
             num_words = len(data)
+        except TypeError:
+            pass
         data_size_bits = num_words * buffer['config'].word_size_bits
         
         return self.controllers[buffer_name].schedule_request(

--- a/tests/test_buffer_write_size.py
+++ b/tests/test_buffer_write_size.py
@@ -15,3 +15,19 @@ def test_write_request_size_matches_data_length():
     queued_request = controller.request_queue[0][2]
     expected_bits = len(data) * cfg['buf'].word_size_bits
     assert queued_request.size_bits == expected_bits
+
+
+def test_np_array_write_records_expected_size():
+    cfg = {
+        'buf': MemoryConfig(memory_type=MemoryType.SRAM, size_kb=4, banks=1, word_size_bits=16)
+    }
+    bm = BufferManager(cfg)
+    region_id = bm.allocate_buffer('buf', size_words=32)
+    assert region_id is not None
+    data = np.arange(8, dtype=np.int16)
+    req_id = bm.write_data('buf', region_id, 0, data)
+    assert req_id is not None
+    controller = bm.controllers['buf']
+    queued_request = controller.request_queue[0][2]
+    expected_bits = len(data) * cfg['buf'].word_size_bits
+    assert queued_request.size_bits == expected_bits


### PR DESCRIPTION
## Summary
- compute write request size based on `len(data)` when available
- test array writes record correct size

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684bb804b518832f9f05b5eb143116e1