### PR TITLE
Add advanced model demos and tiny hardware config

### DIFF
--- a/examples/demo_models.py
+++ b/examples/demo_models.py
@@ -5,6 +5,8 @@ Demo script with different model examples for the ReRAM crossbar simulator
 
 import sys
 import os
+import argparse
+
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
 
 import numpy as np
@@ -13,6 +15,14 @@ from core.crossbar import CrossbarConfig
 from core.dnn_manager import DNNManager, DNNConfig, LayerConfig, LayerType
 from core.execution_engine import ExecutionEngine, ExecutionConfig
 from visualization.text_viz import create_complete_text_report
+from examples.hardware_configurations import (
+    create_edge_device_config,
+    create_mobile_edge_config,
+    create_server_config,
+    create_automotive_config,
+    create_research_config,
+    create_heterogeneous_config,
+)
 
 def create_tiny_cnn():
     """Create a tiny CNN for quick testing"""
@@ -174,6 +184,164 @@ def create_cifar_cnn():
         precision=8
     )
 
+def create_vgg_cnn():
+    """Create a small VGG-style CNN"""
+    layers = [
+        LayerConfig(
+            layer_type=LayerType.CONV2D,
+            input_shape=(32, 32, 3),
+            output_shape=(30, 30, 64),
+            kernel_size=(3, 3),
+            activation="relu",
+            weights_shape=(3, 3, 3, 64)
+        ),
+        LayerConfig(
+            layer_type=LayerType.CONV2D,
+            input_shape=(30, 30, 64),
+            output_shape=(28, 28, 64),
+            kernel_size=(3, 3),
+            activation="relu",
+            weights_shape=(3, 3, 64, 64)
+        ),
+        LayerConfig(
+            layer_type=LayerType.POOLING,
+            input_shape=(28, 28, 64),
+            output_shape=(14, 14, 64),
+            kernel_size=(2, 2)
+        ),
+        LayerConfig(
+            layer_type=LayerType.CONV2D,
+            input_shape=(14, 14, 64),
+            output_shape=(12, 12, 128),
+            kernel_size=(3, 3),
+            activation="relu",
+            weights_shape=(3, 3, 64, 128)
+        ),
+        LayerConfig(
+            layer_type=LayerType.CONV2D,
+            input_shape=(12, 12, 128),
+            output_shape=(10, 10, 128),
+            kernel_size=(3, 3),
+            activation="relu",
+            weights_shape=(3, 3, 128, 128)
+        ),
+        LayerConfig(
+            layer_type=LayerType.POOLING,
+            input_shape=(10, 10, 128),
+            output_shape=(5, 5, 128),
+            kernel_size=(2, 2)
+        ),
+        LayerConfig(
+            layer_type=LayerType.DENSE,
+            input_shape=(5 * 5 * 128,),
+            output_shape=(512,),
+            activation="relu",
+            weights_shape=(5 * 5 * 128, 512)
+        ),
+        LayerConfig(
+            layer_type=LayerType.DENSE,
+            input_shape=(512,),
+            output_shape=(10,),
+            activation="softmax",
+            weights_shape=(512, 10)
+        )
+    ]
+
+    return DNNConfig(
+        model_name="VGG_CNN",
+        layers=layers,
+        input_shape=(32, 32, 3),
+        output_shape=(10,),
+        precision=8
+    )
+
+def create_resnet_cnn():
+    """Create a small ResNet-style CNN"""
+    layers = [
+        LayerConfig(
+            layer_type=LayerType.CONV2D,
+            input_shape=(32, 32, 3),
+            output_shape=(30, 30, 16),
+            kernel_size=(3, 3),
+            activation="relu",
+            weights_shape=(3, 3, 3, 16)
+        ),
+        LayerConfig(
+            layer_type=LayerType.CONV2D,
+            input_shape=(30, 30, 16),
+            output_shape=(28, 28, 16),
+            kernel_size=(3, 3),
+            activation="relu",
+            weights_shape=(3, 3, 16, 16)
+        ),
+        LayerConfig(
+            layer_type=LayerType.CONV2D,
+            input_shape=(28, 28, 16),
+            output_shape=(26, 26, 32),
+            kernel_size=(3, 3),
+            activation="relu",
+            weights_shape=(3, 3, 16, 32)
+        ),
+        LayerConfig(
+            layer_type=LayerType.CONV2D,
+            input_shape=(26, 26, 32),
+            output_shape=(24, 24, 32),
+            kernel_size=(3, 3),
+            activation="relu",
+            weights_shape=(3, 3, 32, 32)
+        ),
+        LayerConfig(
+            layer_type=LayerType.POOLING,
+            input_shape=(24, 24, 32),
+            output_shape=(12, 12, 32),
+            kernel_size=(2, 2)
+        ),
+        LayerConfig(
+            layer_type=LayerType.CONV2D,
+            input_shape=(12, 12, 32),
+            output_shape=(10, 10, 64),
+            kernel_size=(3, 3),
+            activation="relu",
+            weights_shape=(3, 3, 32, 64)
+        ),
+        LayerConfig(
+            layer_type=LayerType.CONV2D,
+            input_shape=(10, 10, 64),
+            output_shape=(8, 8, 64),
+            kernel_size=(3, 3),
+            activation="relu",
+            weights_shape=(3, 3, 64, 64)
+        ),
+        LayerConfig(
+            layer_type=LayerType.POOLING,
+            input_shape=(8, 8, 64),
+            output_shape=(4, 4, 64),
+            kernel_size=(2, 2)
+        ),
+        LayerConfig(
+            layer_type=LayerType.DENSE,
+            input_shape=(4 * 4 * 64,),
+            output_shape=(128,),
+            activation="relu",
+            weights_shape=(4 * 4 * 64, 128)
+        ),
+        LayerConfig(
+            layer_type=LayerType.DENSE,
+            input_shape=(128,),
+            output_shape=(10,),
+            activation="softmax",
+            weights_shape=(128, 10)
+        )
+    ]
+
+    return DNNConfig(
+        model_name="ResNet_CNN",
+        layers=layers,
+        input_shape=(32, 32, 3),
+        output_shape=(10,),
+        precision=8
+    )
+
 def create_adaptive_hardware(dnn_config):
     """Create hardware that adapts to DNN requirements"""
     hw_requirement = DNNManager(dnn_config).hw_requirement
@@ -205,15 +373,21 @@ def create_adaptive_hardware(dnn_config):
     
     return ReRAMChip(chip_config)
 
-def run_model_demo(model_name, dnn_config, execute_inference=True):
+def run_model_demo(model_name, dnn_config, hardware_creator=None, execute_inference=True):
     """Run demo for a specific model"""
     print(f"\n{'='*60}")
     print(f"🧠 DEMO: {model_name}")
     print(f"{'='*60}")
     
-    # Create adaptive hardware
-    print("1. Creating adaptive hardware configuration...")
-    chip = create_adaptive_hardware(dnn_config)
+    # Create hardware
+    if hardware_creator is None:
+        hardware_creator = create_adaptive_hardware
+
+    print("1. Creating hardware configuration...")
+    if hardware_creator is create_adaptive_hardware:
+        chip = hardware_creator(dnn_config)
+    else:
+        chip = hardware_creator()
     config = chip.get_chip_configuration()
     print(f"   ✓ Hardware created: {config['compute_capacity']['total_crossbars']} crossbars")
     
@@ -290,20 +464,68 @@ def run_model_demo(model_name, dnn_config, execute_inference=True):
 
 def main():
     """Main demo function"""
+    parser = argparse.ArgumentParser(description="Model demo")
+    parser.add_argument(
+        "--model",
+        default="tiny",
+        choices=["tiny", "mnist", "cifar", "vgg", "resnet", "all"],
+        help="Select model to run"
+    )
+    parser.add_argument(
+        "--hardware",
+        default="adaptive",
+        choices=[
+            "adaptive",
+            "edge",
+            "mobile_edge",
+            "server",
+            "automotive",
+            "research",
+            "heterogeneous",
+        ],
+        help="Hardware configuration template"
+    )
+    parser.add_argument("--no-exec", action="store_true", help="Skip inference")
+    args = parser.parse_args()
+
     print("🎯 ReRAM Crossbar Simulator - Model Demos")
-    print("="*60)
-    
-    models = [
-        ("Tiny CNN", create_tiny_cnn()),
-        ("MNIST CNN", create_mnist_cnn()),
-        ("CIFAR CNN", create_cifar_cnn())
-    ]
+    print("=" * 60)
+
+    model_creators = {
+        "tiny": create_tiny_cnn,
+        "mnist": create_mnist_cnn,
+        "cifar": create_cifar_cnn,
+        "vgg": create_vgg_cnn,
+        "resnet": create_resnet_cnn,
+    }
+
+    hardware_creators = {
+        "adaptive": create_adaptive_hardware,
+        "edge": create_edge_device_config,
+        "mobile_edge": create_mobile_edge_config,
+        "server": create_server_config,
+        "automotive": create_automotive_config,
+        "research": create_research_config,
+        "heterogeneous": create_heterogeneous_config,
+    }
+
+    if args.model == "all":
+        models = [(name.capitalize() + " CNN", func()) for name, func in model_creators.items()]
+    else:
+        models = [(args.model.capitalize() + " CNN", model_creators[args.model]())]
+
+    hardware_creator = hardware_creators.get(args.hardware, create_adaptive_hardware)
     
     results = {}
-    
+
     for model_name, dnn_config in models:
         try:
-            result = run_model_demo(model_name, dnn_config, execute_inference=True)
+            result = run_model_demo(
+                model_name,
+                dnn_config,
+                hardware_creator=hardware_creator,
+                execute_inference=not args.no_exec,
+            )
             results[model_name] = result
             
             if result and isinstance(result, dict) and result.get('success'):
@@ -340,14 +562,21 @@ def main():
             print(f"\n🔍 DETAILED REPORT FOR: {model_name}")
             
             # Re-create the components for visualization
-            if model_name == "Tiny CNN":
+            if model_name.startswith("Tiny"):
                 dnn_config = create_tiny_cnn()
-            elif model_name == "MNIST CNN":
+            elif model_name.startswith("MNIST"):
                 dnn_config = create_mnist_cnn()
-            elif model_name == "CIFAR CNN":
+            elif model_name.startswith("CIFAR"):
                 dnn_config = create_cifar_cnn()
-                
-            chip = create_adaptive_hardware(dnn_config)
+            elif model_name.startswith("VGG"):
+                dnn_config = create_vgg_cnn()
+            else:
+                dnn_config = create_resnet_cnn()
+            chip = (
+                hardware_creator(dnn_config)
+                if hardware_creator is create_adaptive_hardware
+                else hardware_creator()
+            )
             dnn_manager = DNNManager(dnn_config, chip)
             
             # Create dummy weight data for mapping


### PR DESCRIPTION
## Summary
- add VGG and ResNet CNN creators
- allow choosing models and hardware configs from demo_models.py CLI
- introduce `create_mobile_edge_config` for minimal IoT devices
- include new hardware option in comparison table

## Testing
- `python -m py_compile examples/demo_models.py examples/hardware_configurations.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684bb9446768832fbcd038b5395f8331