### PR TITLE
Add tests for new VGG and ResNet model mapping

### DIFF
--- a/tests/test_new_model_mapping.py
+++ b/tests/test_new_model_mapping.py
@@ -1,0 +1,38 @@
+import numpy as np
+
+from src import DNNManager, create_default_chip
+from examples.demo_models import create_vgg_cnn, create_resnet_cnn
+
+
+def generate_weight_data(dnn_config):
+    weight_data = {}
+    idx = 0
+    for layer in dnn_config.layers:
+        if layer.weights_shape is not None:
+            weight_data[f"layer_{idx}"] = np.random.randn(*layer.weights_shape)
+            idx += 1
+    return weight_data
+
+
+def test_vgg_model_mapping():
+    dnn_config = create_vgg_cnn()
+    dnn_config.precision = 1
+    chip = create_default_chip(crossbar_size=(128, 128), num_crossbars=128)
+    manager = DNNManager(dnn_config, chip)
+
+    weight_data = generate_weight_data(dnn_config)
+    manager.map_dnn_to_hardware(weight_data)
+    validation = manager.validate_hardware_capacity()
+    assert validation["overall_sufficient"]
+
+
+def test_resnet_model_mapping():
+    dnn_config = create_resnet_cnn()
+    dnn_config.precision = 1
+    chip = create_default_chip(crossbar_size=(128, 128), num_crossbars=32)
+    manager = DNNManager(dnn_config, chip)
+
+    weight_data = generate_weight_data(dnn_config)
+    manager.map_dnn_to_hardware(weight_data)
+    validation = manager.validate_hardware_capacity()
+    assert validation["overall_sufficient"]


### PR DESCRIPTION
## Summary
- add `test_new_model_mapping.py` under tests
- construct VGG and ResNet models, auto-generate weight data
- map models to hardware and validate capacity

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684bbddfcc88832fb7028e4b59670f2f