### PR TITLE
Add peripheral conversion tracking

### DIFF
--- a/src/visualization/text_viz.py
+++ b/src/visualization/text_viz.py
@@ -142,6 +142,20 @@ def print_performance_summary(statistics):
             print(f"   ├── IPC: {ipc:.3f}")
         print(f"   └── Energy: {mcu_stats.get('energy_consumption', 0):.2e} J")
 
+def print_system_report(statistics):
+    """Print a concise system statistics report including peripheral usage."""
+    print("\n📑 SYSTEM REPORT")
+    print("─" * 60)
+    print_performance_summary(statistics)
+
+    peripheral_stats = statistics.get('peripheral_statistics', {})
+    adc_conv = peripheral_stats.get('adc_conversions', 0)
+    dac_conv = peripheral_stats.get('dac_conversions', 0)
+    if adc_conv or dac_conv:
+        print(f"\n🔹 Peripheral Activity:")
+        print(f"   ├── DAC Conversions: {dac_conv:,}")
+        print(f"   └── ADC Conversions: {adc_conv:,}")
+
 def print_layer_execution_log(layer_log):
     """Print layer execution timeline"""
     print("\n⏱️  LAYER EXECUTION TIMELINE")

--- a/tests/test_peripheral_counters.py
+++ b/tests/test_peripheral_counters.py
@@ -1,0 +1,16 @@
+import numpy as np
+
+from src.core.crossbar import CrossbarArray, CrossbarConfig
+from src.core.peripherals import PeripheralManager
+
+
+def test_mvm_updates_peripheral_counters():
+    cfg = CrossbarConfig(rows=4, cols=4)
+    xbar = CrossbarArray(cfg)
+    pm = PeripheralManager(num_rows=cfg.rows, num_cols=cfg.cols)
+    weights = np.eye(cfg.rows, cfg.cols)
+    xbar.program_weights(weights)
+    inp = np.arange(cfg.rows)
+    xbar.matrix_vector_multiply(inp, peripheral_manager=pm)
+    assert sum(d.conversion_count for d in pm.input_dacs) == cfg.rows
+    assert sum(a.conversion_count for a in pm.output_adcs) == cfg.cols


### PR DESCRIPTION
## Summary
- convert inputs/outputs via PeripheralManager in `CrossbarArray`
- pass PeripheralManager when executing layers
- track peripheral usage in `_collect_system_statistics`
- display peripheral counts in `text_viz`
- test DAC/ADC counters increment during MVM

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684bc15f1b58832fba4e596f1154d9a8