### PR TITLE
Fix: Resolve test failures and potential core dump causes

### DIFF
--- a/examples/simple_test.py
+++ b/examples/simple_test.py
@@ -68,7 +68,8 @@ def create_test_hardware() -> ReRAMChip:
     tile_config = TileConfig(
         crossbars_per_tile=4,
         crossbar_config=crossbar_config,
-        local_buffer_size=32
+        local_buffer_size=32,
+        adcs_per_tile=64  # Ensure enough ADCs for one crossbar
     )
     
     supertile_config = SuperTileConfig(
@@ -129,7 +130,7 @@ def test_basic_functionality():
         print(f"   ✓ Successfully mapped {len(layer_mappings)} layers to hardware")
     except Exception as e:
         print(f"   ✗ Weight mapping failed: {e}")
-        return False
+        assert False, f"Weight mapping failed: {e}"
     
     # 6. Test inference
     print("6. Testing inference execution...")
@@ -159,11 +160,11 @@ def test_basic_functionality():
                       
         else:
             print(f"   ✗ Inference failed: {result.get('error', 'Unknown error')}")
-            return False
+            assert False, f"Inference failed: {result.get('error', 'Unknown error')}"
             
     except Exception as e:
         print(f"   ✗ Inference execution failed: {e}")
-        return False
+        assert False, f"Inference execution failed: {e}"
     
     # 7. Test crossbar operations
     print("7. Testing crossbar operations...")
@@ -191,14 +192,14 @@ def test_basic_functionality():
         
     except Exception as e:
         print(f"   ✗ Crossbar operation test failed: {e}")
-        return False
+        assert False, f"Crossbar operation test failed: {e}"
     
     print("\n" + "=" * 50)
     print("✅ All tests passed successfully!")
     print("🎉 ReRAM Crossbar Simulator is working correctly!")
     print("=" * 50)
     
-    return True
+    assert True  # All tests passed
 
 def test_performance_analysis():
     """Test performance analysis features"""


### PR DESCRIPTION
I investigated a core dump issue you reported when running pytest. My investigation found and fixed the following:

1.  **ADC Configuration in simple_test.py:** I modified `examples/simple_test.py` to set `adcs_per_tile=64` for the `TileConfig`. The previous default (32) was insufficient for the 64x64 crossbars, causing a "PeripheralManager lacks sufficient ADC units" error.

2.  **Pytest Structure in simple_test.py:** I updated the `test_basic_functionality` function in `examples/simple_test.py` to use `assert` statements instead of returning boolean values. This resolves a `PytestReturnNotNoneWarning` and aligns with pytest best practices.

Additionally, I identified that `numpy`, `matplotlib`, and `seaborn` dependencies were missing during testing and installed them. I recommend that you update `requirements.txt` accordingly.

After these changes and dependency installations, both `examples/simple_test.py` and the full `pytest` suite run successfully without any core dumps.